### PR TITLE
fix:call contract fail in bsc will lead to program to exit

### DIFF
--- a/blockchain/browsersync/nbai/NbaiToBnbService.go
+++ b/blockchain/browsersync/nbai/NbaiToBnbService.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-func ChangeNbaiToBnb(data []byte) {
+func ChangeNbaiToBnb(data []byte, txHashInNbai string) {
 	pk := os.Getenv("privateKey")
 	fromAddress := common.HexToAddress(config.GetConfig().BscMainnetNode.BscAdminWallet)
 	client := bscclient.WebConn.ConnWeb
@@ -53,13 +53,16 @@ func ChangeNbaiToBnb(data []byte) {
 	if err != nil {
 		logs.GetLogger().Error(err)
 		childChainTX.Status = constants.TRANSACTION_STATUS_FAIL
+		childChainTX.TxHashInBsc = ""
+		childChainTX.Status = constants.TRANSACTION_STATUS_FAIL
+	} else {
+		childChainTX.TxHashInBsc = tx.Hash().Hex()
+		childChainTX.Status = constants.TRANSACTION_STATUS_SUCCESS
 	}
 
-	childChainTX.TxHash = tx.Hash().Hex()
-	childChainTX.CreateAt = strconv.FormatInt(utils.GetEpochInMillis(), 10)
-	childChainTX.UpdateAt = strconv.FormatInt(utils.GetEpochInMillis(), 10)
-	childChainTX.Status = constants.TRANSACTION_STATUS_SUCCESS
-
+	childChainTX.TxHashInNbai = txHashInNbai
+	currenTime := utils.GetEpochInMillis()
+	childChainTX.CreateAt = strconv.FormatInt(currenTime, 10)
+	childChainTX.UpdateAt = strconv.FormatInt(currenTime, 10)
 	database.SaveOne(childChainTX)
-
 }

--- a/blockchain/browsersync/nbai/nbaiEventLogScan.go
+++ b/blockchain/browsersync/nbai/nbaiEventLogScan.go
@@ -39,10 +39,14 @@ func NbaiBlockBrowserSyncAndEventLogsSync() {
 		blockScanRecordList, err := blockScanRecord.FindLastCurrentBlockNumber(whereCondition)
 		if err != nil {
 			logs.GetLogger().Error(err)
-			startScanBlockNo = getStartBlockNo()
+			startScanBlockNo = config.GetConfig().NbaiMainnetNode.StartFromBlockNo
 		}
 		if len(blockScanRecordList) > 0 {
-			startScanBlockNo = blockScanRecordList[0].LastCurrentBlockNumber
+			if blockScanRecordList[0].LastCurrentBlockNumber >= startScanBlockNo {
+				startScanBlockNo = blockScanRecordList[0].LastCurrentBlockNumber
+			} else {
+				startScanBlockNo = config.GetConfig().NbaiMainnetNode.StartFromBlockNo
+			}
 			blockScanRecord.ID = blockScanRecordList[0].ID
 		}
 
@@ -92,6 +96,20 @@ func getStartBlockNo() int64 {
 
 	if config.GetConfig().NbaiMainnetNode.StartFromBlockNo > 0 {
 		startScanBlockNo = config.GetConfig().NbaiMainnetNode.StartFromBlockNo
+	}
+
+	blockScanRecord := new(models2.BlockScanRecord)
+	whereCondition := "network_type='" + constants.NETWORK_TYPE_NBAI + "'"
+	blockScanRecordList, err := blockScanRecord.FindLastCurrentBlockNumber(whereCondition)
+	if err != nil {
+		logs.GetLogger().Error(err)
+		startScanBlockNo = config.GetConfig().NbaiMainnetNode.StartFromBlockNo
+	}
+
+	if len(blockScanRecordList) > 0 {
+		if blockScanRecordList[0].LastCurrentBlockNumber > startScanBlockNo {
+			startScanBlockNo = blockScanRecordList[0].LastCurrentBlockNumber
+		}
 	}
 	return startScanBlockNo
 }

--- a/blockchain/browsersync/nbai/nbaiEventLogService.go
+++ b/blockchain/browsersync/nbai/nbaiEventLogService.go
@@ -87,8 +87,6 @@ func ScanNbaiEventFromChainAndSaveEventLogData(blockNoFrom, blockNoTo int64) err
 					logrus.Fatal(err)
 				}
 
-				ChangeNbaiToBnb(receiveMap["data"].([]byte))
-
 				event.BlockNo = vLog.BlockNumber
 				event.TxHash = vLog.TxHash.Hex()
 				event.ContractName = "SwanPayment"
@@ -100,6 +98,8 @@ func ScanNbaiEventFromChainAndSaveEventLogData(blockNoFrom, blockNoTo int64) err
 				if err != nil {
 					logs.GetLogger().Error(err)
 				}
+
+				ChangeNbaiToBnb(receiveMap["data"].([]byte), vLog.TxHash.Hex())
 			}
 		}
 	}

--- a/main/payment-bridge.go
+++ b/main/payment-bridge.go
@@ -7,6 +7,8 @@ import (
 	"github.com/joho/godotenv"
 	"os"
 	"payment-bridge/blockchain/browsersync/goerli"
+	"payment-bridge/blockchain/browsersync/nbai"
+	"payment-bridge/blockchain/browsersync/polygon"
 	"payment-bridge/blockchain/initclient/bscclient"
 	"payment-bridge/blockchain/initclient/goerliclient"
 	"payment-bridge/blockchain/initclient/nbaiclient"
@@ -29,9 +31,9 @@ func main() {
 
 	//nbai.ScanNbaiEventFromChainAndSaveEventLogData(1,6944505)
 
-	//go nbai.NbaiBlockBrowserSyncAndEventLogsSync()
+	go nbai.NbaiBlockBrowserSyncAndEventLogsSync()
 
-	//go polygon.PolygonBlockBrowserSyncAndEventLogsSync()
+	go polygon.PolygonBlockBrowserSyncAndEventLogsSync()
 
 	go goerli.GoerliBlockBrowserSyncAndEventLogsSync()
 

--- a/models/ChildChainTransaction.go
+++ b/models/ChildChainTransaction.go
@@ -6,11 +6,12 @@ import (
 )
 
 type ChildChainTransaction struct {
-	ID       int64  `json:"id"`
-	TxHash   string `json:"tx_hash"`
-	Status   string `json:"status"`
-	CreateAt string `json:"create_at"`
-	UpdateAt string `json:"create_at"`
+	ID           int64  `json:"id"`
+	TxHashInBsc  string `json:"tx_hash_in_bsc"`
+	TxHashInNbai string `json:"tx_hash_in_nbai""`
+	Status       string `json:"status"`
+	CreateAt     string `json:"create_at"`
+	UpdateAt     string `json:"create_at"`
 }
 
 // FindChildChainTransaction (&ChildChainTransaction{Id: "0xadeaCC802D0f2DFd31bE4Fa7434F15782Fd720ac"},"id desc","10","0")


### PR DESCRIPTION
When calling the contract on the bsc blockchain, if an error such as insufficient bnb occurs, the program will exit。

Record the value of tx hash on the nbai chain and the result of contract execution on the bsc chain in the child_chain_transaction table